### PR TITLE
Fix issue when calling with description argument

### DIFF
--- a/src/codebooks/__main__.py
+++ b/src/codebooks/__main__.py
@@ -90,6 +90,7 @@ def main():
             .fillna("")
             .to_dict()
         )
+        desc = desc['description']
     else:
         desc = {}
 

--- a/src/codebooks/html.py
+++ b/src/codebooks/html.py
@@ -97,7 +97,7 @@ class SummaryRow(object):
         Set the variable description, if available.
         """
         if self.var.desc:
-            self.desc = "<p>{}</p>".format(var.desc)
+            self.desc = "<p>{}</p>".format(self.var.desc)
         else:
             self.desc = ""
 


### PR DESCRIPTION
Currently any table given as description argument will be ignored, because the variables are in a further indirection, i.e. desc = {description: {variable_1: description_1, ...}}, which is solved by this changes.